### PR TITLE
Don't register the `class_exists` loader

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -20,10 +20,6 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL') && !class_exists('PHPUnit_TextUI_Comman
 // Enforce a consistent locale
 setlocale(LC_ALL, 'C');
 
-if (!class_exists('Doctrine\Common\Annotations\AnnotationRegistry', false) && class_exists('Doctrine\Common\Annotations\AnnotationRegistry')) {
-    AnnotationRegistry::registerLoader('class_exists');
-}
-
 if ('disabled' !== getenv('SYMFONY_DEPRECATIONS_HELPER')) {
     DeprecationErrorHandler::register(getenv('SYMFONY_DEPRECATIONS_HELPER'));
 }


### PR DESCRIPTION
This is now done when the container boots in Symfony 3.3.x.

https://github.com/symfony/symfony/pull/21837 registers this loader now. Registering it twice is expensive as it gets called a *LOT*. Especially during tests. In a comparison of Symfony 3.2.10 and 3.3.4 a single test was calling `class_exists` 90K more times.

https://blackfire.io/profiles/compare/0c3627c5-8432-4908-b097-1289b81d63bb/graph

This isn't the best solution, but I'm not sure how to detect the version of Symfony from within the bootstrap.php file so this would be a BC break for any version of Symfony before 3.3.

I also created https://github.com/doctrine/annotations/pull/135
to address this, but wanted to cover all bases.