### PR TITLE
Ability to use different composer.json file

### DIFF
--- a/bin/simple-phpunit
+++ b/bin/simple-phpunit
@@ -26,8 +26,10 @@ if (PHP_VERSION_ID >= 70200) {
     $PHPUNIT_VERSION = '4.8';
 }
 
+$COMPOSER_FILE_NAME = getenv('COMPOSER_FILE_NAME') ? : 'composer.json';
+
 $root = __DIR__;
-while (!file_exists($root.'/composer.json') || file_exists($root.'/DeprecationErrorHandler.php')) {
+while (!file_exists($root.'/'.$COMPOSER_FILE_NAME) || file_exists($root.'/DeprecationErrorHandler.php')) {
     if ($root === dirname($root)) {
         break;
     }


### PR DESCRIPTION
Hi, I have a project where I use a different composer.json via environment variable. Look [here](https://getcomposer.org/doc/03-cli.md#composer). Because of this, $root gets set to "/" and everything fails.

Hope this helps.