### PR TITLE
Fixes compatibility issue with PHPUnit 7

### DIFF
--- a/Legacy/TestRunner.php
+++ b/Legacy/TestRunner.php
@@ -21,11 +21,11 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner
     /**
      * {@inheritdoc}
      */
-    protected function handleConfiguration(array &$arguments)
+    protected function handleConfiguration(array &$arguments): void
     {
         $listener = new SymfonyTestsListenerForV5();
 
-        $result = parent::handleConfiguration($arguments);
+        parent::handleConfiguration($arguments);
 
         $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
@@ -42,7 +42,5 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner
         if (!$registeredLocally) {
             $arguments['listeners'][] = $listener;
         }
-
-        return $result;
     }
 }

--- a/TextUI/TestRunner.php
+++ b/TextUI/TestRunner.php
@@ -27,11 +27,11 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
         /**
          * {@inheritdoc}
          */
-        protected function handleConfiguration(array &$arguments)
+        protected function handleConfiguration(array &$arguments): void
         {
             $listener = new SymfonyTestsListener();
 
-            $result = parent::handleConfiguration($arguments);
+            parent::handleConfiguration($arguments);
 
             $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : array();
 
@@ -48,8 +48,6 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
             if (!$registeredLocally) {
                 $arguments['listeners'][] = $listener;
             }
-
-            return $result;
         }
     }
 }


### PR DESCRIPTION
Running `./vendor/bin/simple-phpunit` results in an error:

```
PHP Fatal error:  Declaration of Symfony\Bridge\PhpUnit\TextUI\TestRunner::handleConfiguration(array &$arguments) must be compatible with PHPUnit\TextUI\TestRunner::handleConfiguration(array &$arguments): void in /Users/emarref/Projects/weirdly/weirdly/vendor/symfony/phpunit-bridge/TextUI/TestRunner.php on line 25
```

This branch matches the `handleConfiguration()` signature to the PHPUnit parent class.