### PR TITLE
PHPUNIT 5.7 -> 5.7.26 (404 Error when download phpunit)

### DIFF
--- a/bin/simple-phpunit
+++ b/bin/simple-phpunit
@@ -50,7 +50,7 @@ if (PHP_VERSION_ID >= 70200) {
     $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '6.5');
 } elseif (PHP_VERSION_ID >= 50600) {
     // PHPUnit 4 does not support PHP 7
-    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '5.7');
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '5.7.26');
 } else {
     // PHPUnit 5.1 requires PHP 5.6+
     $PHPUNIT_VERSION = '4.8';


### PR DESCRIPTION
At this time, 5.7 ZIP return 404 error. So we can change to 5.7.26 ZIP.