### PR TITLE
Add: CommandForV9_3

### DIFF
--- a/Legacy/CommandForV9_3.php
+++ b/Legacy/CommandForV9_3.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+use PHPUnit\TextUI\Command as BaseCommand;
+use PHPUnit\TextUI\Configuration\Registry;
+use PHPUnit\TextUI\TestRunner as BaseRunner;
+use PHPUnit\TextUI\XmlConfiguration\Configuration;
+use PHPUnit\TextUI\XmlConfiguration\Loader;
+use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
+
+/**
+ * {@inheritdoc}
+ *
+ * @internal
+ */
+class CommandForV9_3 extends BaseCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createRunner(): BaseRunner
+    {
+        $this->arguments['listeners'] = isset($this->arguments['listeners']) ? $this->arguments['listeners'] : [];
+
+        $registeredLocally = false;
+
+        foreach ($this->arguments['listeners'] as $registeredListener) {
+            if ($registeredListener instanceof SymfonyTestsListener) {
+                $registeredListener->globalListenerDisabled();
+                $registeredLocally = true;
+                break;
+            }
+        }
+
+        if (isset($this->arguments['configuration'])) {
+            $configuration = $this->arguments['configuration'];
+            if (!$configuration instanceof Configuration) {
+                $configuration = (new Loader)->load($this->arguments['configuration']);
+            }
+            foreach ($configuration->listeners() as $registeredListener) {
+                if ('Symfony\Bridge\PhpUnit\SymfonyTestsListener' === ltrim($registeredListener->className(), '\\')) {
+                    $registeredLocally = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$registeredLocally) {
+            $this->arguments['listeners'][] = new SymfonyTestsListener();
+        }
+
+        return parent::createRunner();
+    }
+}

--- a/TextUI/Command.php
+++ b/TextUI/Command.php
@@ -15,9 +15,12 @@ if (version_compare(\PHPUnit\Runner\Version::id(), '6.0.0', '<')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\CommandForV5', 'Symfony\Bridge\PhpUnit\TextUI\Command');
 } elseif (version_compare(\PHPUnit\Runner\Version::id(), '9.0.0', '<')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\CommandForV6', 'Symfony\Bridge\PhpUnit\TextUI\Command');
-} else {
+} elseif (version_compare(\PHPUnit\Runner\Version::id(), '9.2.0', '<')) {
     class_alias('Symfony\Bridge\PhpUnit\Legacy\CommandForV9', 'Symfony\Bridge\PhpUnit\TextUI\Command');
+} else {
+    class_alias('Symfony\Bridge\PhpUnit\Legacy\CommandForV9_3', 'Symfony\Bridge\PhpUnit\TextUI\Command');
 }
+
 
 if (false) {
     class Command


### PR DESCRIPTION
Necessary because configuration classes moved in PhpUnit 9.3.

I am not 100% sure if adding 9_3 is right or if it would be enough to just edit CommandForV9.
I am looking forward to your feedback.