### PR TITLE
Fix problem when SYMFONY_PHPUNIT_VERSION is empty string value

### DIFF
--- a/bin/simple-phpunit.php
+++ b/bin/simple-phpunit.php
@@ -17,9 +17,12 @@ error_reporting(-1);
 global $argv, $argc;
 $argv = isset($_SERVER['argv']) ? $_SERVER['argv'] : [];
 $argc = isset($_SERVER['argc']) ? $_SERVER['argc'] : 0;
-$getEnvVar = function ($name, $default = false) use ($argv) {
-    if (false !== $value = getenv($name)) {
-        return $value;
+$getEnvVar = function ($name, $default = false, $useDefaultWhenEmpty = false) use ($argv) {
+    $value = getenv($name);
+    if (false !== $value) {
+        if ($value || !$useDefaultWhenEmpty) {
+            return $value;
+        }
     }
 
     static $phpunitConfig = null;
@@ -95,19 +98,19 @@ $passthruOrFail = function ($command) {
 
 if (\PHP_VERSION_ID >= 80000) {
     // PHP 8 requires PHPUnit 9.3+
-    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '9.4');
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '9.4', true);
 } elseif (\PHP_VERSION_ID >= 70200) {
     // PHPUnit 8 requires PHP 7.2+
-    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '8.3');
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '8.3', true);
 } elseif (\PHP_VERSION_ID >= 70100) {
     // PHPUnit 7 requires PHP 7.1+
-    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '7.5');
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '7.5', true);
 } elseif (\PHP_VERSION_ID >= 70000) {
     // PHPUnit 6 requires PHP 7.0+
-    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '6.5');
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '6.5', true);
 } elseif (\PHP_VERSION_ID >= 50600) {
     // PHPUnit 4 does not support PHP 7
-    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '5.7');
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '5.7', true);
 } else {
     // PHPUnit 5.1 requires PHP 5.6+
     $PHPUNIT_VERSION = '4.8';


### PR DESCRIPTION
This should fix that when `SYMFONY_PHPUNIT_VERSION` is set again on empty:

```
SYMFONY_PHPUNIT_VERSION= vendor/bin/simple-phpunit
```

it does not error with:

```bash
Creating a "phpunit/phpunit" project at "./phpunit--1"


  [UnexpectedValueException]
  Could not parse version constraint .*: Invalid version string ".*"
```